### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Matumo/x-post-button/security/code-scanning/1](https://github.com/Matumo/x-post-button/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions:` block for the workflow or for each job, rather than relying on inherited defaults. Since this workflow only checks out code, runs npm scripts, and uploads artifacts, it needs at most `contents: read` for `actions/checkout`; artifact uploads do not rely on repository write permissions.

The best fix here is to add a workflow-level `permissions:` block (applies to all jobs by default) directly under the `name:` line, before the `on:` section, with `contents: read`. This keeps behavior identical while ensuring `GITHUB_TOKEN` is limited to read-only access to repository contents. No other permissions are required by the shown steps. Only `.github/workflows/ci.yml` needs to be modified, and no additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
